### PR TITLE
Constraint files omitted in previous PR (release 12.3-v3.0)

### DIFF
--- a/Libero_Projects/import/components/M2S150-1FC1152/AHB/import_component_and_constraints_sf2_adv_dev_kit_ahb.tcl
+++ b/Libero_Projects/import/components/M2S150-1FC1152/AHB/import_component_and_constraints_sf2_adv_dev_kit_ahb.tcl
@@ -15,7 +15,6 @@ puts "--------------------APPLYING DESING CONSTRAINTS--------------------------"
 puts "-------------------------------------------------------------------------"
 
 import_files -io_pdc ./import/constraints/io/io_constraints.pdc
-import_files -io_pdc ./import/constraints/io/user.pdc
 import_files -sdc    ./import/constraints/io_jtag_constraints.sdc
 
 build_design_hierarchy
@@ -26,7 +25,6 @@ run_tool -name {CONSTRAINT_MANAGEMENT}
 organize_tool_files -tool {PLACEROUTE} \
     -file $project_dir2/constraint/io_jtag_constraints.sdc \
     -file $project_dir2/constraint/io/io_constraints.pdc \
-	-file $project_dir2/constraint/io/user.pdc \
     -module {BaseDesign::work} -input_type {constraint}  
     
 organize_tool_files -tool {SYNTHESIZE} \

--- a/Libero_Projects/import/components/M2S150-1FC1152/AXI/import_component_and_constraints_sf2_adv_dev_kit_axi.tcl
+++ b/Libero_Projects/import/components/M2S150-1FC1152/AXI/import_component_and_constraints_sf2_adv_dev_kit_axi.tcl
@@ -13,7 +13,6 @@ puts "--------------------APPLYING DESING CONSTRAINTS--------------------------"
 puts "-------------------------------------------------------------------------"
 
 import_files -io_pdc ./import/constraints/io/io_constraints.pdc
-import_files -io_pdc ./import/constraints/io/user.pdc
 import_files -sdc    ./import/constraints/io_jtag_constraints.sdc
 
 build_design_hierarchy
@@ -24,7 +23,6 @@ run_tool -name {CONSTRAINT_MANAGEMENT}
 organize_tool_files -tool {PLACEROUTE} \
     -file $project_dir2/constraint/io_jtag_constraints.sdc \
     -file $project_dir2/constraint/io/io_constraints.pdc \
-	-file $project_dir2/constraint/io/user.pdc \
     -module {BaseDesign::work} -input_type {constraint}  
     
 organize_tool_files -tool {SYNTHESIZE} \

--- a/Libero_Projects/import/components/M2S150TS-1FC1152/AHB/import_component_and_constraints_sf2_adv_dev_kit_ts_ahb.tcl
+++ b/Libero_Projects/import/components/M2S150TS-1FC1152/AHB/import_component_and_constraints_sf2_adv_dev_kit_ts_ahb.tcl
@@ -13,7 +13,6 @@ puts "--------------------APPLYING DESING CONSTRAINTS--------------------------"
 puts "-------------------------------------------------------------------------"
 
 import_files -io_pdc ./import/constraints/io/io_constraints.pdc
-import_files -io_pdc ./import/constraints/io/user.pdc
 import_files -sdc    ./import/constraints/io_jtag_constraints.sdc
 
 build_design_hierarchy
@@ -24,7 +23,6 @@ run_tool -name {CONSTRAINT_MANAGEMENT}
 organize_tool_files -tool {PLACEROUTE} \
     -file $project_dir2/constraint/io_jtag_constraints.sdc \
     -file $project_dir2/constraint/io/io_constraints.pdc \
-	-file $project_dir2/constraint/io/user.pdc \
     -module {BaseDesign::work} -input_type {constraint}  
     
 organize_tool_files -tool {SYNTHESIZE} \

--- a/Libero_Projects/import/components/M2S150TS-1FC1152/AXI/import_component_and_constraints_sf2_adv_dev_kit_ts_axi.tcl
+++ b/Libero_Projects/import/components/M2S150TS-1FC1152/AXI/import_component_and_constraints_sf2_adv_dev_kit_ts_axi.tcl
@@ -15,7 +15,6 @@ puts "--------------------APPLYING DESING CONSTRAINTS--------------------------"
 puts "-------------------------------------------------------------------------"
 
 import_files -io_pdc ./import/constraints/io/io_constraints.pdc
-import_files -io_pdc ./import/constraints/io/user.pdc
 import_files -sdc    ./import/constraints/io_jtag_constraints.sdc
 
 build_design_hierarchy
@@ -26,7 +25,6 @@ run_tool -name {CONSTRAINT_MANAGEMENT}
 organize_tool_files -tool {PLACEROUTE} \
     -file $project_dir2/constraint/io_jtag_constraints.sdc \
     -file $project_dir2/constraint/io/io_constraints.pdc \
-	-file $project_dir2/constraint/io/user.pdc \
     -module {BaseDesign::work} -input_type {constraint}  
     
 organize_tool_files -tool {SYNTHESIZE} \


### PR DESCRIPTION
These constraint files were meant to be part of the update (release 12.3-v3.0) but, were omitted. They correspond to programming files already in the repository.